### PR TITLE
Fix uncaught MetadataMissingError in WebP metadata extraction

### DIFF
--- a/src/components/Root.vue
+++ b/src/components/Root.vue
@@ -29,7 +29,7 @@
               v-if="showCopyBtn(item.key)">
               <template #reference>
                 <el-button style="margin-left: 6px" :icon="CopyDocument" :link="true" @click="item.key == 'Comment' ? copy(jsonData.uc) : copy(item.value)
-      " />
+                  " />
               </template>
             </el-popover>
           </h1>
@@ -413,9 +413,14 @@ const readImageBase64 = async () => {
 }
 
 const readExif = async (file) => {
-  const data = await ExifReader.load(file);
-  const entries = Object.entries(data);
-  return entries.map(([key, value]) => ({ key, value }));
+  try {
+    const data = await ExifReader.load(file);
+    const entries = Object.entries(data);
+    return entries.map(([key, value]) => ({ key, value }));
+  }
+  catch (MetadataMissingError) {
+    return [];
+  }
 }
 
 const printableBytes = (size) => {


### PR DESCRIPTION
An uncaught `MetadataMissingError` might occur when extracting info from WebP images with no metadata chunk but stealth watermark embedded in alpha channel, stopping the extraction process even if the stealth watermark can be read, causing a blank output.

By adding a try-catch block, the issue can be fixed.

An example input is as uploaded: [👻.zip](https://github.com/user-attachments/files/16202191/default.zip).

A comparison between the current output and NAI's inspector:

![screenshot1](https://github.com/user-attachments/assets/ec5ebe3c-b1c8-46d4-8eba-4ef16aea9c56)
![screenshot2](https://github.com/user-attachments/assets/c98e182b-89a2-4e9c-92f2-e0f4477c97d4)


